### PR TITLE
Multi part pull request - Build and work on modern distributions.

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -1,8 +1,15 @@
-obj-m = playground.o
-all:
-	make -C /lib/modules/`uname -r`/build M=$(PWD) modules
+ifneq ($(KERNELRELEASE),)
+# kbuild part of makefile
+obj-m  := playground.o
+# playground-y := playground.o
 
-clean:
-	rm -rf Module.symvers playground.ko playground.mod.c \
-	.playground.mod.o.cmd .playground.o.cmd modules.order \
-	.playground.ko.cmd playground.mod.o playground.o .tmp_versions
+else
+
+# normal makefile
+KDIR ?= /lib/modules/`uname -r`/build
+
+default:
+	$(MAKE) -C $(KDIR) M=$$PWD
+
+endif
+

--- a/module/Makefile
+++ b/module/Makefile
@@ -1,6 +1,8 @@
 ifneq ($(KERNELRELEASE),)
 # kbuild part of makefile
 obj-m  := playground.o
+ccflags-y := -Wno-missing-attributes
+
 # playground-y := playground.o
 
 else
@@ -9,7 +11,7 @@ else
 KDIR ?= /lib/modules/`uname -r`/build
 
 default:
-	$(MAKE) -C $(KDIR) M=$$PWD
+	$(MAKE) -C $(KDIR) M=$$PWD modules 
 
 endif
 

--- a/module/playground.c
+++ b/module/playground.c
@@ -24,7 +24,7 @@
  */
 
 #include "playground.h"
-#include <asm/uaccess.h>
+#include <linux/uaccess.h> 
 #include <linux/fs.h>
 #include <linux/kernel.h>
 #include <linux/errno.h>
@@ -33,6 +33,9 @@
 #include <linux/cred.h>
 #include <linux/slab.h>
 #include <linux/sched.h>
+#include <linux/module.h>
+
+
 
 static void *playground[PLAYGROUND_SIZE];
 
@@ -174,9 +177,7 @@ static void __exit playground_exit(void)
 {
 	int ret;
 
-	ret = misc_deregister(&playground_misc);
-	if (unlikely(ret))
-		printk(KERN_ERR "playground: failed to unregister misc device\n");
+	misc_deregister(&playground_misc);
 
 	for (ret = 0; ret < PLAYGROUND_SIZE; ret++) {
 		if (playground[ret]) {


### PR DESCRIPTION
Gday,

So, I made some minor changes so that this will build nicely on modern linux distros.  I realise its a bit of a mess in one heap, I can break it up if you'd like into more specific chunks, but I can't honestly say I can test without all the changes.

1) The makefile change was to allow this:

make KDIR=/home/wmealing/build/usr/src/kernels/4.18.0-193.el8.x86_64/ M=$PWD

This was required as I'm not always/or even regularly testing against the kernel module that I am booting.

2) The uaccess path has changed over time and from what I can tell this new linux/uaccess.h is the accepted method of accessing the functions.

3) The misc_deregister now has a void return, so the return value can't be used, unless I had missed the entire point of this.

Thank you for considering these changes.

Wade mealing
