### PR TITLE
Include unistd.h as close as it is not imported by default and close() requires it.

### DIFF
--- a/lib/libplayground.c
+++ b/lib/libplayground.c
@@ -19,6 +19,7 @@
 
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 #include "playground.h"
 
 /* Global file descriptor to device file */


### PR DESCRIPTION
The userspace tools require unistd.h header file to be included as modern versions of gcc require importing it specifically to work correctly.

This patch modifies the libplayground shared library to specifically include it.

Thanks again.

Wade